### PR TITLE
fix: add actions:write permission to sync-upstream workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   sync:


### PR DESCRIPTION
This resolves the GitHub Actions permission error that occurs when the upstream sync tries to update workflow files like codeql-analysis.yml.